### PR TITLE
Add array support

### DIFF
--- a/to_map.go
+++ b/to_map.go
@@ -7,21 +7,53 @@ import (
 	"github.com/joeycumines/go-dotnotation/dotnotation"
 )
 
-// ToMap converts the item (struct) to a map.
+// ToMap converts the item (struct or array of structs) to a map.
 // Only the fields in the fieldsToInclude list are included.
 // This list supports the dot operator to access nested fields.
+// This function panics if the field cannot be found or set.
+// If you are calling this function with a dynamically built list of fieldsToInclude, you may want to use the priv.ToMapErr alternative.
 //
 // eg.
-//  user := {ID: "123", Some: {Nested: {Field: "abc"}}, SomethingElse: true}
-//  ToMap(user, "ID", "Some.Nested.Field->Renamed.Location")
+//  users := [{ID: "123", Some: {Nested: {Field: "abc"}}, SomethingElse: true}]
+//  ToMap(users, "ID", "Some.Nested.Field")
 // would result in:
-//  {ID: "123", Renamed: {Location: "abc"}}
+//  [{ID: "123", Some: {Nested: {Field: "abc"}}]
 func ToMap(item interface{}, fieldsToInclude ...string) interface{} {
+	value, err := ToMapErr(item, fieldsToInclude...)
+	if err != nil {
+		panic("priv.ToMap: " + err.Error())
+	}
+
+	return value
+}
+
+// ToMapErr does the same thing as priv.ToMap, but returns an error if the field cannot be found or set.
+// Most of the time panicing (as priv.ToMap does) is fine, since the fields are set before compiling, so a panic to warn of a typo is not a big deal.
+func ToMapErr(item interface{}, fieldsToInclude ...string) (interface{}, error) {
 	reflectItem := reflect.ValueOf(item)
+
+	// If it is an array or slice
+	if reflectItem.Kind() == reflect.Slice || reflectItem.Kind() == reflect.Array {
+		result := []interface{}{}
+
+		// Iterate over it, to convert each item to a map
+		for i := 0; i < reflectItem.Len(); i++ {
+			value, err := toMap(reflectItem.Index(i), fieldsToInclude...)
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, value)
+		}
+
+		return result, nil
+	}
+
+	// Otherwise, convert the item to a map
 	return toMap(reflectItem, fieldsToInclude...)
 }
 
-func toMap(item reflect.Value, fieldsToInclude ...string) interface{} {
+func toMap(item reflect.Value, fieldsToInclude ...string) (interface{}, error) {
 	// Convert the struct to a map
 	sMap := structs.Map(item.Interface())
 
@@ -44,15 +76,14 @@ func toMap(item reflect.Value, fieldsToInclude ...string) interface{} {
 		// Grab the value
 		value, err := sMapAccessor.Get(sMap, field)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		// Set the value in the results
-		err = resultAccessor.Set(result, field, value)
-		if err != nil {
-			panic(err)
+		if err := resultAccessor.Set(result, field, value); err != nil {
+			return nil, err
 		}
 	}
 
-	return result
+	return result, nil
 }

--- a/to_map_test.go
+++ b/to_map_test.go
@@ -7,122 +7,260 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type DoubleNestedStruct1 struct {
+	Field1 int
+	Field2 float64
+}
+
+type InternalStruct1 struct {
+	Field1 bool
+	Field2 *DoubleNestedStruct1
+}
+
+type TestStruct1 struct {
+	Field1 string
+	Field2 InternalStruct1
+}
+
+var testStruct1 = TestStruct1{
+	Field1: "Value 1",
+	Field2: InternalStruct1{
+		Field1: true,
+		Field2: &DoubleNestedStruct1{
+			Field1: 42,
+			Field2: 150.25,
+		},
+	},
+}
+
+var testStruct2 = TestStruct1{
+	Field1: "Value 2",
+	Field2: InternalStruct1{
+		Field1: true,
+		Field2: &DoubleNestedStruct1{
+			Field1: 45,
+			Field2: 243.42,
+		},
+	},
+}
+
+var testStructSlice = []TestStruct1{testStruct1, testStruct2}
+var testStructArray = [2]TestStruct1{testStruct1, testStruct2}
+
+var cases = []struct {
+	when             string
+	item             interface{}
+	expected         interface{}
+	fieldList        []string
+	shouldPanicOrErr bool
+	isArrayOrSlice   bool
+}{
+	{
+		when:      "no fields are included",
+		fieldList: []string{},
+		item:      testStruct1,
+		expected:  map[string]interface{}{},
+	},
+	{
+		when:      "one field is included",
+		fieldList: []string{"Field1"},
+		item:      testStruct1,
+		expected:  map[string]interface{}{"Field1": testStruct1.Field1},
+	},
+	{
+		when:      "a complete doubly nested field is included",
+		fieldList: []string{"Field2"},
+		item:      testStruct1,
+		expected: map[string]interface{}{
+			"Field2": map[string]interface{}{
+				"Field1": testStruct1.Field2.Field1,
+				"Field2": map[string]interface{}{
+					"Field1": testStruct1.Field2.Field2.Field1,
+					"Field2": testStruct1.Field2.Field2.Field2,
+				},
+			},
+		},
+	},
+	{
+		when:      "all fields are included",
+		fieldList: []string{"Field2", "Field1"},
+		item:      testStruct1,
+		expected: map[string]interface{}{
+			"Field1": testStruct1.Field1,
+			"Field2": map[string]interface{}{
+				"Field1": testStruct1.Field2.Field1,
+				"Field2": map[string]interface{}{
+					"Field1": testStruct1.Field2.Field2.Field1,
+					"Field2": testStruct1.Field2.Field2.Field2,
+				},
+			},
+		},
+	},
+	{
+		when:      "a nested field is included",
+		fieldList: []string{"Field2.Field1"},
+		item:      testStruct1,
+		expected: map[string]interface{}{
+			"Field2": map[string]interface{}{
+				"Field1": testStruct1.Field2.Field1,
+			},
+		},
+	},
+	{
+		when:      "all of a doubly nested field is included",
+		fieldList: []string{"Field2.Field2"},
+		item:      testStruct1,
+		expected: map[string]interface{}{
+			"Field2": map[string]interface{}{
+				"Field2": map[string]interface{}{
+					"Field1": testStruct1.Field2.Field2.Field1,
+					"Field2": testStruct1.Field2.Field2.Field2,
+				},
+			},
+		},
+	},
+	{
+		when:      "the first field is included with all of a doubly nested field is included",
+		fieldList: []string{"Field1", "Field2.Field2"},
+		item:      testStruct1,
+		expected: map[string]interface{}{
+			"Field1": testStruct1.Field1,
+			"Field2": map[string]interface{}{
+				"Field2": map[string]interface{}{
+					"Field1": testStruct1.Field2.Field2.Field1,
+					"Field2": testStruct1.Field2.Field2.Field2,
+				},
+			},
+		},
+	},
+	{
+		when:      "one field of a doubly nested field is included",
+		fieldList: []string{"Field2.Field2.Field1"},
+		item:      testStruct1,
+		expected: map[string]interface{}{
+			"Field2": map[string]interface{}{
+				"Field2": map[string]interface{}{
+					"Field1": testStruct1.Field2.Field2.Field1,
+				},
+			},
+		},
+	},
+	{
+		when:             "a non-nested field does not exist",
+		fieldList:        []string{"DNE"},
+		item:             testStruct1,
+		expected:         nil,
+		shouldPanicOrErr: true,
+	},
+	{
+		when:             "a nested field does not exist",
+		fieldList:        []string{"Field2.Field2z.Field1"},
+		item:             testStruct1,
+		expected:         nil,
+		shouldPanicOrErr: true,
+	},
+	{
+		when:           "given a slice, and the first field is included with all of a doubly nested field is included",
+		fieldList:      []string{"Field1", "Field2.Field2"},
+		item:           testStructSlice,
+		isArrayOrSlice: true,
+		expected: []map[string]interface{}{
+			{
+				"Field1": testStruct1.Field1,
+				"Field2": map[string]interface{}{
+					"Field2": map[string]interface{}{
+						"Field1": testStruct1.Field2.Field2.Field1,
+						"Field2": testStruct1.Field2.Field2.Field2,
+					},
+				},
+			},
+			{
+				"Field1": testStruct2.Field1,
+				"Field2": map[string]interface{}{
+					"Field2": map[string]interface{}{
+						"Field1": testStruct2.Field2.Field2.Field1,
+						"Field2": testStruct2.Field2.Field2.Field2,
+					},
+				},
+			},
+		},
+	},
+	{
+		when:           "given an array, and the first field is included with all of a doubly nested field is included",
+		fieldList:      []string{"Field1", "Field2.Field2"},
+		item:           testStructArray,
+		isArrayOrSlice: true,
+		expected: []map[string]interface{}{
+			{
+				"Field1": testStruct1.Field1,
+				"Field2": map[string]interface{}{
+					"Field2": map[string]interface{}{
+						"Field1": testStruct1.Field2.Field2.Field1,
+						"Field2": testStruct1.Field2.Field2.Field2,
+					},
+				},
+			},
+			{
+				"Field1": testStruct2.Field1,
+				"Field2": map[string]interface{}{
+					"Field2": map[string]interface{}{
+						"Field1": testStruct2.Field2.Field2.Field1,
+						"Field2": testStruct2.Field2.Field2.Field2,
+					},
+				},
+			},
+		},
+	},
+	{
+		when:             "given a slice, and a nested field does not exist",
+		fieldList:        []string{"Field2.Field2z.Field1"},
+		item:             testStructSlice,
+		expected:         nil,
+		shouldPanicOrErr: true,
+	},
+	{
+		when:             "given an array, and a nested field does not exist",
+		fieldList:        []string{"Field2.Field2z.Field1"},
+		item:             testStructArray,
+		expected:         nil,
+		shouldPanicOrErr: true,
+	},
+}
+
 func TestToMap(t *testing.T) {
 	r := require.New(t)
 
-	type DoubleNestedStruct1 struct {
-		Field1 int
-		Field2 float64
+	for _, c := range cases {
+		if c.shouldPanicOrErr {
+			defer func() {
+				r.NotNil(recover(), "When "+c.when+", it should panic")
+			}()
+		}
+
+		if c.isArrayOrSlice {
+			r.ElementsMatch(c.expected, priv.ToMap(c.item, c.fieldList...), "When "+c.when)
+		} else {
+			r.Equal(c.expected, priv.ToMap(c.item, c.fieldList...), "When "+c.when)
+		}
 	}
+}
 
-	type InternalStruct1 struct {
-		Field1 bool
-		Field2 *DoubleNestedStruct1
+func TestToMapErr(t *testing.T) {
+	r := require.New(t)
+
+	for _, c := range cases {
+		v, err := priv.ToMapErr(c.item, c.fieldList...)
+
+		if c.shouldPanicOrErr {
+			r.Error(err, "When "+c.when+", it should error")
+		} else {
+			r.NoError(err, "When "+c.when+", it should not error")
+		}
+
+		if c.isArrayOrSlice {
+			r.ElementsMatch(c.expected, v, "When "+c.when)
+		} else {
+			r.Equal(c.expected, v, "When "+c.when)
+		}
 	}
-
-	type TestStruct1 struct {
-		Field1 string
-		Field2 InternalStruct1
-	}
-
-	testStruct1 := TestStruct1{
-		Field1: "Value 1",
-		Field2: InternalStruct1{
-			Field1: true,
-			Field2: &DoubleNestedStruct1{
-				Field1: 42,
-				Field2: 150.25,
-			},
-		},
-	}
-
-	// When no fields are included
-	r.Equal(
-		map[string]interface{}{},
-		priv.ToMap(testStruct1),
-	)
-
-	// When one field is included
-	r.Equal(
-		map[string]interface{}{"Field1": testStruct1.Field1},
-		priv.ToMap(testStruct1, "Field1"),
-	)
-
-	// When a doubly nested field is included
-	r.Equal(
-		map[string]interface{}{
-			"Field2": map[string]interface{}{
-				"Field1": testStruct1.Field2.Field1,
-				"Field2": map[string]interface{}{
-					"Field1": testStruct1.Field2.Field2.Field1,
-					"Field2": testStruct1.Field2.Field2.Field2,
-				},
-			},
-		},
-		priv.ToMap(testStruct1, "Field2"),
-	)
-
-	// When both fields are included
-	r.Equal(
-		map[string]interface{}{
-			"Field1": testStruct1.Field1,
-			"Field2": map[string]interface{}{
-				"Field1": testStruct1.Field2.Field1,
-				"Field2": map[string]interface{}{
-					"Field1": testStruct1.Field2.Field2.Field1,
-					"Field2": testStruct1.Field2.Field2.Field2,
-				},
-			},
-		},
-		priv.ToMap(testStruct1, "Field2", "Field1"),
-	)
-
-	// When part of a doubly nested field is included
-	r.Equal(
-		map[string]interface{}{
-			"Field2": map[string]interface{}{
-				"Field1": testStruct1.Field2.Field1,
-			},
-		},
-		priv.ToMap(testStruct1, "Field2.Field1"),
-	)
-
-	// When part of a doubly nested field is included
-	r.Equal(
-		map[string]interface{}{
-			"Field2": map[string]interface{}{
-				"Field2": map[string]interface{}{
-					"Field1": testStruct1.Field2.Field2.Field1,
-					"Field2": testStruct1.Field2.Field2.Field2,
-				},
-			},
-		},
-		priv.ToMap(testStruct1, "Field2.Field2"),
-	)
-
-	// When part of a doubly nested field is included
-	r.Equal(
-		map[string]interface{}{
-			"Field1": testStruct1.Field1,
-			"Field2": map[string]interface{}{
-				"Field2": map[string]interface{}{
-					"Field1": testStruct1.Field2.Field2.Field1,
-					"Field2": testStruct1.Field2.Field2.Field2,
-				},
-			},
-		},
-		priv.ToMap(testStruct1, "Field1", "Field2.Field2"),
-	)
-
-	// When part of a doubly nested field is included
-	r.Equal(
-		map[string]interface{}{
-			"Field2": map[string]interface{}{
-				"Field2": map[string]interface{}{
-					"Field1": testStruct1.Field2.Field2.Field1,
-				},
-			},
-		},
-		priv.ToMap(testStruct1, "Field2.Field2.Field1"),
-	)
 }


### PR DESCRIPTION
Add support for arrays via the `priv.ToMap` function. Also add a separate `priv.ToMapErr` function that emits errors (vs panics).